### PR TITLE
Update unwrap_fasta.sh to deal with NIH dbSNP format

### DIFF
--- a/docs/unwrap_fasta.help
+++ b/docs/unwrap_fasta.help
@@ -8,8 +8,13 @@
 Remove line wrapping from a fasta file.
 
 Usage (order is important!!):
-unwrap_fasta.sh <input_fasta> <output_fasta>
+unwrap_fasta.sh <input_fasta> [<output_fasta>]
 
-Example:
+The second parameter is optional; if omitted, the output filename is inferred
+from the input filename, less the final extension (e.g., ".fasta").
+
+Examples:
 unwrap_fasta.sh sequences.fasta sequences_unwrapped.fasta
+unwrap_fasta.sh sequences.fasta  # -> sequences_unwrapped.fasta
+
 

--- a/unwrap_fasta.sh
+++ b/unwrap_fasta.sh
@@ -2,7 +2,7 @@
 #
 #  unwrap_fasta.sh - Remove text wrapping from a fasta file
 #
-#  Version 1.1.0 (June 16, 2015)
+#  Version 1.1.1 (July 1, 2015)
 #
 #  Copyright (c) 2014-2015 Andrew Krohn
 #
@@ -22,36 +22,74 @@
 #     misrepresented as being the original software.
 #  3. This notice may not be removed or altered from any source distribution.
 #
+#set -x
 
-## Check whether user had supplied -h or --help. If yes display help 
+## Defaults used by infer_from() function, below
+EXT=fasta
+TAG=_unwrapped
+
+## Check whether user had supplied -h or --help. If yes display help
 
 	if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
-	scriptdir="$( cd "$( dirname "$0" )" && pwd )"
+	scriptdir=$( cd $( dirname "$0" ) && pwd )
 	less $scriptdir/docs/unwrap_fasta.help
 	exit 0
-	fi 
+	fi
 
-# if more or less than one arguments supplied, display usage 
+# if less than one argument supplied or $1 doesn't exist, display usage
 
-	if [  "$#" -ne 2 ] ;
-	then 
+	if [  "$#" -lt 1 -o ! -f "$1" ]; then
+		scriptname=$( basename "$0" )
 		echo "
 Usage (order is important!!):
-unwrap_fasta.sh sequences.fasta sequences_unwrapped.fasta
-		"
+
+  $scriptname <inseq> [<outseq>]
+
+
+  If <outseq> is omitted, output filename is inferred from input:
+
+    $scriptname sequences.$EXT  # -> sequences${TAG}.$EXT
+		" >&2
 		exit 1
-	fi 
+	fi
+
+## Functions
+
+infer_from() {
+	# See https://stackoverflow.com/a/965072 and
+	# http://man.cx/bash#heading14 ("Parameter Expansion")
+	path=$( dirname "$1" )
+	filename=${1##*/}
+	ext=${filename##*.}
+	if [ "$ext" == "$filename" ]; then
+		ext=$EXT                  # default to global $EXT
+	else
+		filename=${filename%.*}   # strip (final) extension
+	fi
+	echo "$path/${filename}${TAG}.${ext}"
+}
 
 ## Define variables
 
 inseqs=$1
-outseqs=$2
+outseqs=${2:-$(infer_from "$1")}
 
 ## Awk script
 
-	awk '!/^>/ { printf "%s", $0; n = "\n" } 
-	/^>/ { print n $0; n = "" }
-	END { printf "%s", n }
+	awk '
+		{if ($1 ~ /^>/ || $0 ~ /^[A-Z]?$/) {
+			# Leave FASTA deflines, IUPAC ambiguity characters, and empty
+			# lines intact (part of the NIH dbSNP "ss" record format; see
+			# ftp://ftp.ncbi.nih.gov/snp/00readme.txt)
+			print n $0;
+			n = "";
+		} else {
+			# Remove spaces and newlines from non-headers
+			gsub(" ", "", $0);
+			printf "%s", $0;
+			n = "\n";
+		}}
+		END { printf "%s", n; }
 	' $inseqs > $outseqs
 	wait
 


### PR DESCRIPTION
NIH's dbSNP [batch upload form](http://www.ncbi.nlm.nih.gov/SNP/dbSNP.cgi?list=rslist) gives you back 10-mers with newlines every 100 bases. I needed them back in one long, contiguous sequence and your repo was high in the search results for "unwrap fasta" for obvious reasons. `:)`

Not sure if this is useful functionality for you, but I modified `unwrap_fasta.sh` to accept files in this format, hopefully without affecting its ability to parse the FASTA files you're normally putting through it. I'm also lazy, so I made the second argument (output filename) optional. It's inferred by adding `_unwrapped` to the "base" part of the input filename.

I tried to respect your preference for tabs over spaces, but if I missed any, I can resubmit the PR, no worries.
